### PR TITLE
Add GitHub Action to run tests

### DIFF
--- a/.github/workflows/Arduino-CI.yaml
+++ b/.github/workflows/Arduino-CI.yaml
@@ -17,12 +17,13 @@ jobs:
           ruby-version: 2.6
 
       # Install and run Arduino CI tests
-      - run: |
-        g++ -v
-        bundle install
-        bundle exec rubocop --version
-        bundle exec rubocop -D .
-        bundle exec rspec --backtrace
-        cd SampleProjects/TestSomething
-        bundle install
-        bundle exec arduino_ci_remote.rb
+      - name: Build and Execute
+        run: |
+          g++ -v
+          bundle install
+          bundle exec rubocop --version
+          bundle exec rubocop -D .
+          bundle exec rspec --backtrace
+          cd SampleProjects/TestSomething
+          bundle install
+          bundle exec arduino_ci_remote.rb

--- a/.github/workflows/Arduino-CI.yaml
+++ b/.github/workflows/Arduino-CI.yaml
@@ -1,0 +1,28 @@
+# This is the name of the workflow, visible on GitHub UI
+name: Arduino CI
+
+# Run on a Push or a Pull Request
+on: [push, pull_request]
+
+jobs:
+  runTest: 
+    runs-on: ubuntu-latest
+    steps:
+      # Clone the repo using the `checkout` action
+      - uses: actions/checkout@v2
+
+      # Get Ruby
+      - uses: ruby/setup-ruby@v1
+        with: 
+          ruby-version: 2.6
+
+      # Install and run Arduino CI tests
+      - run: |
+        g++ -v
+        bundle install
+        bundle exec rubocop --version
+        bundle exec rubocop -D .
+        bundle exec rspec --backtrace
+        cd SampleProjects/TestSomething
+        bundle install
+        bundle exec arduino_ci_remote.rb


### PR DESCRIPTION
We have Travis and Appveyor, but those only run in Arduino-CI/arduino_ci. GitHub actions run by default for any repository.
